### PR TITLE
Completed, need testing - 'start-process', syntax errors fixed

### DIFF
--- a/Powershell/Test.ps1
+++ b/Powershell/Test.ps1
@@ -3,24 +3,16 @@ $web_downloads = @(
     @{Name= "Adobe Acrobat"; FolderName= "Adobe"; URL="https://get.adobe.com/reader/"}
     @{Name= "VLC Media Player"; FolderName= "VideoLAN"; URL="https://www.videolan.org/vlc/download-windows.html"}
 )
-# download the paths from the web and put them where the installation path is going to be 
+# download the paths from the web and put them where the installation path is going to be (i.e. Downloads) 
 ForEach ($software in $web_downloads.GetEnumerator()) {
-    $programFiles = "C:\Program Files\$($web_downloads.FolderName)"
-    $programFilesX86 = "C:\Program File (x86)\$($web_downloads.FolderName)"
+    $programFiles = "C:\Program Files\$($software.FolderName)"  # Used $software instead of @web_development
+    $programFilesX86 = "C:\Program Files (x86)\$($software.FolderName)"
     
     If(!(Test-Path -Path $programFiles) -and !(Test-Path -Path $programFilesX86)) {
-        Invoke-WebRequest -Uri $software.URL -OutFile "$Env:USERPROFILE\Downloads"
-            $installPath = "$Env:USERPROFILE\Downloads\$($software.Name).exe"
-        else {
-            Write-Output "$($software.Name) is already installed."            
-        }
+        Invoke-WebRequest -Uri $software.URL -OutFile "$Env:USERPROFILE\Downloads\$($software.Name).exe"
+        Start-Process -FilePath "$Env:USERPROFILE\Downloads\$($software.Name).exe" -ArgumentList "/silent" -Wait # Ensure install starts after downloading
+    } else {  # Else and If statements are usually on the same level in a loop
+        Write-Output "$($software.Name) is already installed."            
     }
-    
-    & 
-
-
 
 }
-# Make a secure install if to seek if the file is not yet in the system, install it then - if it is in the system Write-Out "already on windows"
-
-# installing the files


### PR DESCRIPTION
Changed By: Michael Lee
Date of Change: 11/14/2024

Following changes were made...

1. On line 8 & 9 there was a ForEach loop variable error where "web_dowloads.FolderName" was used instead of "software.FolderNames" change was correcter.
2. File path to Program Files (x86) was spelled incorrectly and was changed from "Program File (x86)" -> "Program Files (x86)
3. The variable $installPath was removed because it did not make sense - the Invoke-WebRequest cmdlet already provided the script with the "-OutFile" parameter.
4. The Else statement was moved to the same level as the IF condition.
5. Start-Process cmdlet was added within the IF condition to ensure that install will happen after the downloads were completed. The "&" alias was removed from the end and did not make sense.

Testing will still need to be completed as the script may still need more revisions.   